### PR TITLE
ES8388 debug and AudioTools Example

### DIFF
--- a/src/AudioBoard.h
+++ b/src/AudioBoard.h
@@ -23,10 +23,15 @@ public:
   }
 
   bool begin(){
-    AD_LOGD("AudioBoard::begin");
-    bool result = pins.begin() && driver->begin(codec_cfg, pins);
+    AD_LOGD("AudioBoard::pins::begin");
+    bool result_pins = pins.begin();
+    AD_LOGD("AudioBoard::pins::begin::returned:%s", result_pins ? "true" : "false");
+    AD_LOGD("AudioBoard::driver::begin");
+    bool result_driver = driver->begin(codec_cfg, pins);
+    AD_LOGD("AudioBoard::driver::begin::returned:%s", result_driver ? "true" : "false");
     setVolume(DRIVER_DEFAULT_VOLUME);
-    return result;
+    AD_LOGD("AudioBoard::volume::set");
+    return result_pins && result_driver;
   }
 
   /// Starts the processing

--- a/src/Driver.h
+++ b/src/Driver.h
@@ -23,7 +23,7 @@ const samplerate_t rate_code[8] = {RATE_8K, RATE_11K, RATE_16K, RATE_22K,
                                    RATE_24K, RATE_32K, RATE_44K, RATE_48K};
 
 /**
- * @brief I2S configuration and defition of input and output with default values
+ * @brief I2S configuration and definition of input and output with default values
  * @ingroup audio_driver
  * @author Phil Schatzmann
  * @copyright GPLv3
@@ -157,28 +157,38 @@ public:
 class AudioDriver {
 public:
   virtual bool begin(CodecConfig codecCfg, DriverPins &pins) {
-    AD_LOGD("AudioDriver::begin");
+    AD_LOGD("AudioDriver::begin:pins");
     p_pins = &pins;
+    AD_LOGD("AudioDriver::begin:setSPI");
     pins.setSPIActiveForSD(codecCfg.sd_active);
+    AD_LOGD("AudioDriver::begin:setConfig");
     int result = setConfig(codecCfg);
+    AD_LOGD("AudioDriver::begin:setPAPower");
     setPAPower(true);
+    AD_LOGD("AudioDriver::begin:completed");
     return result;
   }
   virtual bool setConfig(CodecConfig codecCfg) {
     codec_cfg = codecCfg;
     if (!init(codec_cfg)) {
-      AD_LOGE("init failed");
+      AD_LOGE("AudioDriver::begin::init failed");
       return false;
+    } else {
+      AD_LOGD("AudioDriver::begin::init succeeded");
     }
     codec_mode_t codec_mode = codec_cfg.get_mode();
     if (!controlState(codec_mode)) {
-      AD_LOGE("controlState failed");
+      AD_LOGE("AudioDriver::begin::controlState failed");
       return false;
+    } else {
+      AD_LOGD("AudioDriver::begin::controlState succeeded");
     }
     bool result = configInterface(codec_mode, codec_cfg.i2s);
     if (!result) {
-      AD_LOGE("configInterface failed");
+      AD_LOGE("AudioDriver::begin::configInterface failed");
       return false;
+    } else {
+      AD_LOGD("AudioDriver::begin::configInterface succeeded");
     }
     return result;
   }
@@ -196,8 +206,7 @@ public:
   /// Sets the PA Power pin to active or inactive
   bool setPAPower(bool enable) {
     GpioPin  pin = pins().getPinID(PinFunction::PA);
-    if (pin == -1)
-      return false;
+    if (pin == -1) { return false; }
     AD_LOGI("setPAPower pin %d -> %d", pin, enable);
     digitalWrite(pin, enable ? HIGH : LOW);
     return true;
@@ -207,7 +216,7 @@ protected:
   CodecConfig codec_cfg;
   DriverPins *p_pins = nullptr;
 
-  /// Detemine the TwoWire object from the I2C config or use Wire
+  /// Determine the TwoWire object from the I2C config or use Wire
   TwoWire* getI2C() {
     if (p_pins == nullptr) return &Wire;
     auto i2c = pins().getI2CPins(PinFunction::CODEC);
@@ -724,7 +733,7 @@ public:
   /// Configuration: define retry count (default : 0)
   void setI2CRetryCount(int cnt) { i2c_retry_count = cnt; }
 
-  /// Configuration: enable/diable PLL (active by default)
+  /// Configuration: enable/disable PLL (active by default)
   void setEnablePLL(bool active) { vs1053_enable_pll = active; }
 
   /// Configuration: define master clock frequency (default: 0)
@@ -853,7 +862,7 @@ public:
 
   virtual bool begin(CodecConfig codecCfg, DriverPins &pins) {
     codec_cfg = codecCfg;
-    // manage reset pin -> acive high
+    // manage reset pin -> active high
     setPAPower(true);
     delay(10);
     p_pins = &pins;

--- a/src/Driver/es8388/es8388.c
+++ b/src/Driver/es8388/es8388.c
@@ -183,7 +183,7 @@ error_t es8388_stop(codec_mode_t mode)
 
 
 /**
- * @brief Config I2s clock in MSATER mode
+ * @brief Config I2s clock in MASTER mode
  *
  * @param cfg.sclkDiv:      generate SCLK by dividing MCLK in MSATER mode
  * @param cfg.lclkDiv:      generate LCLK by dividing MCLK in MSATER mode
@@ -225,6 +225,16 @@ error_t es8388_init(codec_config_t *cfg, i2c_bus_handle_t handle)
     i2c_handle = handle;
 
     int res = 0;
+
+    // Here check if ES8388 is responding on the I2C bus
+    res = i2c_bus_check(handle, ES8388_ADDR);
+    if (res != 0) {
+        AD_LOGE("ES8388 not found on I2C bus, check wiring");
+        return res;
+    } else {
+        AD_LOGI("Found ES8388");
+    }
+
 #ifdef CONFIG_ESP_LYRAT_V4_3_BOARD
     headphone_detect_init(get_headphone_detect_gpio());
 #endif

--- a/src/DriverPins.h
+++ b/src/DriverPins.h
@@ -128,6 +128,8 @@ struct PinsSPI {
         p_spi->begin();
 #endif
       }
+    } else {
+      AD_LOGI("SPI, not active, MOSI, MISO, SCLK, SSEL not modified");
     }
     return true;
   }
@@ -190,6 +192,8 @@ struct PinsI2C {
       }
       AD_LOGI("Setting i2c clock: %u", frequency);
       p_wire->setClock(frequency);
+    } else {
+      AD_LOGI("I2C, not active, SDA, SCL, i2c clock not modified");
     }
     return true;
   }
@@ -315,11 +319,14 @@ public:
     AD_LOGD("DriverPins::begin");
 
     // setup function pins
+    AD_LOGD("DriverPins::begin::setupPinMode");
     setupPinMode();
 
     // setup spi
+    AD_LOGD("DriverPins::begin::SPI");
     bool result = true;
     for (auto &tmp : spi) {
+      AD_LOGD("DriverPins::begin::SPI::begin");
       if (tmp.function == PinFunction::SD)
         if (sd_active)
           result &= tmp.begin();
@@ -328,7 +335,9 @@ public:
     }
 
     // setup i2c
+    AD_LOGD("DriverPins::begin::I2C");
     for (auto &tmp : i2c) {
+      AD_LOGD("DriverPins::begin::I2C::begin");
       result &= tmp.begin();
     }
     return result;
@@ -337,10 +346,12 @@ public:
   void end() {
     // setup spi
     for (auto &tmp : spi) {
+      AD_LOGD("DriverPins::begin::SPI::end");
       tmp.end();
     }
     // setup i2c
     for (auto &tmp : i2c) {
+      AD_LOGD("DriverPins::begin::I2C::end");
       tmp.end();
     }
   }
@@ -388,7 +399,10 @@ protected:
           AD_LOGW("Pin '%d' not set up because of conflict", tmp.pin);
           tmp.active = false;
         }
+      } else {
+        AD_LOGD("Pin is -1");
       }
+      AD_LOGD("Pin %d set", tmp.pin);
     }
   }
 

--- a/src/Utils/I2C.cpp
+++ b/src/Utils/I2C.cpp
@@ -29,6 +29,21 @@ error_t i2c_bus_write_bytes(i2c_bus_handle_t bus, int addr, uint8_t *reg,
   return result;
 }
 
+// this method is used !
+error_t i2c_bus_check(i2c_bus_handle_t bus, int addr) {
+  AD_LOGD("i2c_bus_check: addr=0x%X",addr);
+  TwoWire *p_wire = (TwoWire *)bus;
+  assert(p_wire!=nullptr);
+  int result = RESULT_OK;
+  p_wire->beginTransmission(addr); 
+  int rc = p_wire->endTransmission(I2C_END);
+  if (rc != 0) {
+    AD_LOGE("->p_wire->endTransmission: %d", rc);
+    result = RESULT_FAIL;
+  }
+  return result;
+}
+
 
 /// This method is used
 error_t i2c_bus_read_bytes(i2c_bus_handle_t bus, int addr, uint8_t *reg,

--- a/src/Utils/I2C.h
+++ b/src/Utils/I2C.h
@@ -24,6 +24,18 @@ extern "C" {
  */
 error_t i2c_bus_write_bytes(i2c_bus_handle_t bus, int addr, uint8_t *reg, int regLen, uint8_t *data, int datalen);
 
+/**
+ * @brief Requests ACK from I2C device
+ * 
+ * @param bus        I2C bus handle
+ * @param addr       The address of the device
+ *
+ * @return
+ *     - NULL Fail
+ *     - Others Success
+ */
+error_t i2c_bus_check(i2c_bus_handle_t bus, int addr);
+
 
 /**
  * @brief Read bytes to I2C bus


### PR DESCRIPTION
- Added i2c bus check to request and acknowledgement of an i2c sensor
- Added Debug statements in the library as I was trying to find the i2c configuration issues.
- Changed audiotools-custom-max.ino to include my_pins.begin() and board.begin(), otherwise it will not work on ES8388 PCBArtists breakout board.