### PR TITLE
Passed wire parameter to PinsI2C constructor

### DIFF
--- a/src/DriverPins.h
+++ b/src/DriverPins.h
@@ -245,7 +245,7 @@ class DriverPins {
   void addI2C(PinsI2C pin) { i2c.push_back(pin); }
   void addI2C(PinFunction function, GpioPin scl, GpioPin sda, int port = -1,
               uint32_t frequency = 100000, TwoWire &wire = Wire) {
-    PinsI2C pin(function, scl, sda, port, frequency);
+    PinsI2C pin(function, scl, sda, port, frequency, wire);
     addI2C(pin);
   }
 


### PR DESCRIPTION
```
  void addI2C(PinFunction function, GpioPin scl, GpioPin sda, int port = -1,
              uint32_t frequency = 100000, TwoWire &wire = Wire) {
    PinsI2C pin(function, scl, sda, port, frequency, wire);
    addI2C(pin);
  }```

the wire parameter passed to addI2C function was not passed to PinsI2C constructor.
I added it, i think it's correct.